### PR TITLE
Rename duplicate tag in help file.

### DIFF
--- a/doc/dadbod-ui.txt
+++ b/doc/dadbod-ui.txt
@@ -1,4 +1,4 @@
-*vim-dadbod-ui*
+*dadbod-ui.txt*
 
         Simple UI for https://github.com/tpope/vim-dadbod
 


### PR DESCRIPTION
doc/dadbod-ui.txt has a duplicate tag, namely "vim-dadbod-ui". I changed the first instance (in the first line) to "dadbod-ui.txt" (the name of the file) which seems to be the convention for help files.