### PR TITLE
[Doc] Remove duplicate key

### DIFF
--- a/doc/dadbod-ui.txt
+++ b/doc/dadbod-ui.txt
@@ -413,7 +413,6 @@ g:db_ui_icons
 			'new_query': '+',
 			'tables': '~',
 			'buffers': '»',
-			'buffers': '»',
 			'connection_ok': '✓',
 			'connection_error': '✕',
 		}


### PR DESCRIPTION
It's a small change, but I fixed it.
The key in `g:db_ui_icons` was duplicated, so it was removed.

Thank you.