### PR TITLE
add icon for database type

### DIFF
--- a/autoload/db_ui/drawer.vim
+++ b/autoload/db_ui/drawer.vim
@@ -262,7 +262,7 @@ function! s:drawer.add_db(db) abort
   if self.show_details
     let db_name .= ' ('.a:db.scheme.' - '.a:db.source.')'
   endif
-  call self.add(db_name, 'toggle', 'db', self.get_icon(a:db), a:db.key_name, 0)
+  call self.add(db_name, 'toggle', 'db', self.get_database_icon(a:db), a:db.key_name, 0)
   if !a:db.expanded
     return a:db
   endif
@@ -430,6 +430,22 @@ function! s:drawer.populate_tables(db) abort
     endif
   endfor
   return a:db
+endfunction
+
+function! s:drawer.get_database_icon(item) abort
+  if g:dbui_show_database_icon
+    if a:item.expanded
+      return g:dbui_icons.expanded. ' '.g:dbui_icons.database
+    else
+      return g:dbui_icons.collapsed. ' '.g:dbui_icons.database
+    endif
+  else
+    if a:item.expanded
+      return g:dbui_icons.expanded
+    else
+      return g:dbui_icons.collapsed
+    endif
+  endif
 endfunction
 
 function! s:drawer.get_icon(item) abort

--- a/plugin/db_ui.vim
+++ b/plugin/db_ui.vim
@@ -14,7 +14,9 @@ let g:dbui_disable_mappings = get(g:, 'db_ui_disable_mappings', 0)
 let g:dbui_table_helpers = get(g:, 'db_ui_table_helpers', {})
 let g:dbui_auto_execute_table_helpers = get(g:, 'db_ui_auto_execute_table_helpers', 0)
 let g:dbui_show_help = get(g:, 'db_ui_show_help', 1)
+let g:dbui_show_database_icon = get(g:, 'db_ui_show_database_icon',0)
 let g:dbui_icons = extend({
+      \ 'database': '',
       \ 'expanded': '▾',
       \ 'collapsed': '▸',
       \ 'saved_query': '*',


### PR DESCRIPTION
Add icon for database type. it depends on `nerdfonts`,The default value is `0`, set to `1` means enable it.
```
let g:dbui_show_database_icon= 0
```
Sorry to bother you, I messed up `git rebase` and had to re-clone and commit.