### PR TITLE
Fix to get schema info correctly on Windows

### DIFF
--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -92,5 +92,5 @@ endfunction
 
 function! db_ui#schemas#query(db, query) abort
   let base_query = db#adapter#dispatch(a:db.conn, 'interactive')
-  return systemlist(printf('%s %s', base_query, a:query))
+  return map(systemlist(printf('%s %s', base_query, a:query)), 'substitute(v:val, "\r$", "", "")')
 endfunction


### PR DESCRIPTION
In the case of Windows, the `systemlist()` result contains a CR (`\r`) at the end, so I trim it.

Before:
![image](https://user-images.githubusercontent.com/16581287/80805297-9c5e6580-8bf2-11ea-9244-75da086fc3a6.png)

After:
![image](https://user-images.githubusercontent.com/16581287/80805331-b7c97080-8bf2-11ea-99c9-6c9e27fa0ffe.png)

Thank you!