### PR TITLE
Fix issue with more than one row of sqlite tables

### DIFF
--- a/autoload/db_ui/drawer.vim
+++ b/autoload/db_ui/drawer.vim
@@ -458,7 +458,6 @@ function! s:drawer.populate_tables(db) abort
     let temp_table_list = []
 
     for table_index in a:db.tables.list
-      echom table_index
       let temp_table_list += map(split(copy(table_index)), 'trim(v:val)')
     endfor
 

--- a/autoload/db_ui/drawer.vim
+++ b/autoload/db_ui/drawer.vim
@@ -453,9 +453,16 @@ function! s:drawer.populate_tables(db) abort
   endif
 
   let a:db.tables.list = tables
-  " Fix issue with sqlite tables listing as single string with spaces
-  if a:db.scheme =~? '^sqlite' && len(a:db.tables.list) ==? 1
-    let a:db.tables.list = map(split(copy(a:db.tables.list[0])), 'trim(v:val)')
+  " Fix issue with sqlite tables listing as strings with spaces
+  if a:db.scheme =~? '^sqlite' && len(a:db.tables.list) >=? 0
+    let temp_table_list = []
+
+    for table_index in a:db.tables.list
+      echom table_index
+      let temp_table_list += map(split(copy(table_index)), 'trim(v:val)')
+    endfor
+
+    let a:db.tables.list = temp_table_list
   endif
 
   call self.populate_table_items(a:db.tables)


### PR DESCRIPTION
The previous fix only covered one row, generating up to 3 table entries in the drawer.
Now, the drawer will also handle (i.e.) 12 tables correctly.