### PR TITLE
Dbout window column name yanking.

### DIFF
--- a/autoload/db_ui/dbout.vim
+++ b/autoload/db_ui/dbout.vim
@@ -55,6 +55,33 @@ function! db_ui#dbout#yank_cell_value() abort
   call setreg(v:register, field_value)
 endfunction
 
+function! db_ui#dbout#yank_header() abort
+  let parsed = db#url#parse(b:db)
+  let scheme = db_ui#schemas#get(parsed.scheme)
+  if empty(scheme)
+    return db_ui#utils#echo_err('Yanking headers not supported for '.parsed.scheme.' scheme.')
+  endif
+
+  let table_line = '-'
+  let column_line = getline(scheme.cell_line_number-1)
+  let underline = getline(scheme.cell_line_number)
+  let from = 0
+  let to = 0
+  let i = 0
+  let columns=[]
+  let lastcol = strlen(underline)
+  while i <= lastcol
+    if underline[i] !=? table_line || i == lastcol
+      let to = i-1
+      call add(columns, trim(column_line[from:to]))
+      let from = i+1
+    endif
+    let i += 1
+  endwhile
+  let csv_columns = join(columns, ', ')
+  call setreg(v:register, csv_columns)
+endfunction
+
 function! s:get_cell_range(line, col) abort
   let table_line = '-'
   let col = a:col - 1

--- a/plugin/db_ui.vim
+++ b/plugin/db_ui.vim
@@ -130,8 +130,10 @@ augroup dbui
   autocmd FileType dbout
         \ nnoremap <silent><buffer> <Plug>(DBUI_JumpToForeignKey) :call db_ui#dbout#jump_to_foreign_table()<CR>
         \ | nnoremap <silent><buffer> <Plug>(DBUI_YankCellValue) :call db_ui#dbout#yank_cell_value()<CR>
+        \ | nnoremap <silent><buffer> <Plug>(DBUI_YankHeader) :call db_ui#dbout#yank_header()<CR>
         \ | call s:set_mapping('<C-]>', '<Plug>(DBUI_JumpToForeignKey)')
         \ | call s:set_mapping('yic', '<Plug>(DBUI_YankCellValue)')
+        \ | call s:set_mapping('yh', '<Plug>(DBUI_YankHeader)')
 augroup END
 
 command! DBUI call db_ui#open('<mods>')


### PR DESCRIPTION
Allow yanking of column names in the dbout windows using `yh` mapping.

Rather than try complicated templates for insert, select, update etc its probably more useful to just be able to use the column names from a query in whatever context you like. I've added a mapping `yh` to be able to yank the headers from the dbout window.