### PR TITLE
Improved Oracle Support

### DIFF
--- a/autoload/db_ui.vim
+++ b/autoload/db_ui.vim
@@ -103,7 +103,8 @@ function! db_ui#query(query) abort
     throw 'Unsupported scheme '.parsed.scheme
   endif
 
-  let result = db_ui#schemas#query({ 'conn': b:db }, printf(scheme.args, a:query))
+  let result = db_ui#schemas#query({ 'conn': b:db, 'scheme': parsed.scheme }, printf(scheme.args, a:query))
+
   return scheme.parse_results(result, 0)
 endfunction
 

--- a/autoload/db_ui/dbout.vim
+++ b/autoload/db_ui/dbout.vim
@@ -10,7 +10,7 @@ function! db_ui#dbout#jump_to_foreign_table() abort
   let field_name = trim(getline(cell_line_number - 1)[(cell_range.from):(cell_range.to)])
   let field_value = trim(getline('.')[(cell_range.from):(cell_range.to)])
   let foreign_key_query = substitute(scheme.foreign_key_query, '{col_name}', field_name, '')
-  let result = scheme.parse_results(db_ui#schemas#query({ 'conn': b:db }, foreign_key_query), 3)
+  let result = scheme.parse_results(db_ui#schemas#query({ 'conn': b:db, 'scheme': parsed.scheme }, foreign_key_query), 3)
   if empty(result)
     return db_ui#notifications#error('No valid foreign key found.')
   endif

--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -86,19 +86,44 @@ let s:mysql = {
       \ 'quote': 0,
       \ }
 
-let s:oracle_args = "echo \"SET linesize 4000;\nSET pagesize 4000;\nCOLUMN owner FORMAT a20;\nCOLUMN table_name FORMAT a25;\nCOLUMN column_name FORMAT a25;\n%s\" | "
+let s:oracle_args = 'echo "'.join(
+      \    [
+           \  'SET linesize 4000',
+           \  'SET pagesize 4000',
+           \  'COLUMN owner FORMAT a20',
+           \  'COLUMN table_name FORMAT a25',
+           \  'COLUMN column_name FORMAT a25',
+           \  '%s',
+      \    ],
+      \    ";\n"
+      \ ).';" |'
+let s:oracle_foreign_key_query = "
+      \ SELECT DISTINCT RFRD.table_name, RFRD.column_name, RFRD.owner
+      \ FROM all_cons_columns RFRD
+      \ JOIN all_constraints CON ON RFRD.constraint_name = CON.r_constraint_name
+      \ JOIN all_cons_columns RFRING ON CON.constraint_name = RFRING.constraint_name
+      \ JOIN all_users U ON CON.owner = U.username
+      \ WHERE CON.constraint_type = 'R'
+      \ AND U.common = 'NO'
+      \ AND RFRING.column_name = '{col_name}'"
+let s:oracle_schemes_tables_query = "
+      \ SELECT T.owner, T.table_name
+      \ FROM all_tables T
+      \ JOIN all_users U ON T.owner = U.username
+      \ WHERE U.common = 'NO'
+      \ ORDER BY T.table_name"
 let s:oracle = {
-\   'args': s:oracle_args,
-\   'cell_line_number': 1,
-\   'cell_line_pattern': '^-\+\( \+-\+\)*',
-\   'default_scheme': '',
-\   'foreign_key_query': printf(s:oracle_args, "SELECT DISTINCT RFRD.table_name, RFRD.column_name, RFRD.owner FROM all_cons_columns RFRD JOIN all_constraints CON ON RFRD.constraint_name = CON.r_constraint_name JOIN all_cons_columns RFRING ON CON.constraint_name = RFRING.constraint_name JOIN all_users U ON CON.owner = U.username WHERE CON.constraint_type = 'R' AND U.common = 'NO' AND RFRING.column_name = '{col_name}';"),
-\   'parse_results': {results, min_len -> s:results_parser(results[15:-5], '\s\s\+', min_len)},
-\   'quote': 1,
-\   'schemes_query': printf(s:oracle_args, "SELECT username FROM all_users WHERE common = 'NO' ORDER BY username;"),
-\   'schemes_tables_query': printf(s:oracle_args, "SELECT T.owner, T.table_name FROM all_tables T JOIN all_users U ON T.owner = U.username WHERE U.common = 'NO' ORDER BY T.table_name;"),
-\   'select_foreign_key_query': 'SELECT * FROM %s.%s WHERE %s = %s;',
-\ }
+      \   'args': s:oracle_args,
+      \   'cell_line_number': 1,
+      \   'cell_line_pattern': '^-\+\( \+-\+\)*',
+      \   'default_scheme': '',
+      \   'foreign_key_query': printf(s:oracle_args, s:oracle_foreign_key_query),
+      \   'parse_results': {results, min_len -> s:results_parser(results[15:-5], '\s\s\+', min_len)},
+      \   'quote': 1,
+      \   'schemes_query': printf(s:oracle_args, "SELECT username FROM all_users WHERE common = 'NO' ORDER BY username"),
+      \   'schemes_tables_query': printf(s:oracle_args, s:oracle_schemes_tables_query),
+      \   'select_foreign_key_query': printf(s:oracle_args, 'SELECT * FROM %s.%s WHERE %s = %s'),
+      \ }
 
 let s:schemas = {
       \ 'postgres': s:postgresql,

--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -86,53 +86,19 @@ let s:mysql = {
       \ 'quote': 0,
       \ }
 
-let s:oracle_foreign_key_query =<< EOF
-	select
-		l.column_name,
-		l.owner,
-		l.table_name
-	from
-		all_constraints n,
-		all_cons_columns l,
-		all_users u
-	where
-		n.constraint_type = 'R'
-	and
-		n.constraint_name = l.constraint_name
-	and
-		n.owner = l.owner
-	and
-		l.owner = u.username
-	and
-		u.common = 'NO'
-	and exists
-	(
-		SELECT a.constraint_name, a.table_name
-		FROM all_constraints a
-		WHERE a.constraint_name = n.r_constraint_name
-		AND a.constraint_type = 'P'
-	)
-	order by
-		l.table_name,
-		l.owner,
-		l.column_name
-	;
-EOF
-
-let s:oracle_foreign_key_query = join(s:oracle_foreign_key_query)
-let s:oracle_args = 'echo "%s" | '
+let s:oracle_args = "echo \"SET linesize 4000;\nSET pagesize 4000;\nCOLUMN owner FORMAT a20;\nCOLUMN table_name FORMAT a25;\nCOLUMN column_name FORMAT a25;\n%s\" | "
 let s:oracle = {
-      \ 'args': s:oracle_args,
-      \ 'cell_line_number': 1,
-      \ 'cell_line_pattern': '^-\+$',
-      \ 'default_scheme': '',
-      \ 'foreign_key_query': printf(s:oracle_args, s:oracle_foreign_key_query),
-      \ 'parse_results': {results, min_len -> s:results_parser(results[1:], '\t', min_len)},
-      \ 'quote': 0,
-      \ 'schemes_query': printf(s:oracle_args, "SELECT username FROM all_users WHERE common = 'NO';"),
-      \ 'schemes_tables_query': printf(s:oracle_args, "SELECT t.owner, t.table_name FROM all_tables t, all_users u WHERE t.owner = u.username AND u.common = 'NO';"),
-      \ 'select_foreign_key_query': 'SELECT * FROM %s.%s WHERE %s = %s;',
-      \ }
+\   'args': s:oracle_args,
+\   'cell_line_number': 1,
+\   'cell_line_pattern': '^-\+\( \+-\+\)*',
+\   'default_scheme': '',
+\   'foreign_key_query': printf(s:oracle_args, "SELECT DISTINCT RFRD.table_name, RFRD.column_name, RFRD.owner FROM all_cons_columns RFRD JOIN all_constraints CON ON RFRD.constraint_name = CON.r_constraint_name JOIN all_cons_columns RFRING ON CON.constraint_name = RFRING.constraint_name JOIN all_users U ON CON.owner = U.username WHERE CON.constraint_type = 'R' AND U.common = 'NO' AND RFRING.column_name = '{col_name}';"),
+\   'parse_results': {results, min_len -> s:results_parser(results[15:-5], '\s\s\+', min_len)},
+\   'quote': 1,
+\   'schemes_query': printf(s:oracle_args, "SELECT username FROM all_users WHERE common = 'NO' ORDER BY username;"),
+\   'schemes_tables_query': printf(s:oracle_args, "SELECT T.owner, T.table_name FROM all_tables T JOIN all_users U ON T.owner = U.username WHERE U.common = 'NO' ORDER BY T.table_name;"),
+\   'select_foreign_key_query': 'SELECT * FROM %s.%s WHERE %s = %s;',
+\ }
 
 let s:schemas = {
       \ 'postgres': s:postgresql,
@@ -156,5 +122,12 @@ endfunction
 
 function! db_ui#schemas#query(db, query) abort
   let base_query = db#adapter#dispatch(a:db.conn, 'interactive')
-  return map(systemlist(printf('%s %s', base_query, a:query)), 'substitute(v:val, "\r$", "", "")')
+  return map(
+  \   systemlist(
+  \     a:db.scheme ==# 'oracle' ?
+  \       printf('%s %s', a:query, base_query) :
+  \       printf('%s %s', base_query, a:query)
+  \   ),
+  \   'substitute(v:val, "\r$", "", "")'
+  \ )
 endfunction

--- a/autoload/db_ui/table_helpers.vim
+++ b/autoload/db_ui/table_helpers.vim
@@ -32,23 +32,72 @@ let s:mysql = {
       \ 'Primary Keys': "SELECT * FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA = '{schema}' AND TABLE_NAME = '{table}' AND CONSTRAINT_TYPE = 'PRIMARY KEY'",
       \ }
 
-let s:oracle_from = ' FROM all_constraints N JOIN all_cons_columns L ON N.constraint_name = L.constraint_name AND N.owner = L.owner '
-let s:oracle_order_by = " L.table_name = '{table}' ORDER BY "
-let s:oracle_key_cmd = 'SELECT L.table_name, L.column_name'.s:oracle_from."WHERE N.constraint_type = '%s' AND".s:oracle_order_by.'L.column_name;'
+let s:oracle_from = "
+      \FROM all_constraints N\n
+      \JOIN all_cons_columns L\n\t
+      \ON N.constraint_name = L.constraint_name\n\t
+      \AND N.owner = L.owner"
+let s:oracle_qualify_and_order_by = "
+      \L.table_name = '{table}'\n
+      \ORDER BY\n\t"
+let s:oracle_key_cmd = "
+      \SELECT\n\t
+      \L.table_name,\n\t
+      \L.column_name\n
+      \" . s:oracle_from . "\n
+      \WHERE\n\t
+      \N.constraint_type = '%s'\n\t
+      \AND " . s:oracle_qualify_and_order_by . "L.column_name"
 
 let s:oracle = {
-\   'Columns': 'DESCRIBE "{schema}"."{table}";',
-\   'Foreign Keys': printf(s:oracle_key_cmd, 'R'),
-\   'Indexes': "SELECT DISTINCT N.owner, N.index_name, N.constraint_type".s:oracle_from."WHERE".s:oracle_order_by."N.index_name;",
-\   'List': 'SELECT * FROM "{schema}"."{table}";',
-\   'Primary Keys': printf(s:oracle_key_cmd, 'P'),
-\   'References': "SELECT RFRING.owner, RFRING.table_name, RFRING.column_name FROM all_cons_columns RFRING JOIN all_constraints N ON RFRING.constraint_name = N.constraint_name JOIN all_cons_columns RFRD ON N.r_constraint_name = RFRD.constraint_name JOIN all_users U ON N.owner = U.username WHERE N.constraint_type = 'R' AND U.common = 'NO' AND RFRD.owner = '{schema}' AND RFRD.table_name = '{table}' ORDER BY RFRING.owner, RFRING.table_name, RFRING.column_name;",
-\ }
+      \ 'Columns': 'DESCRIBE "{schema}"."{table}"',
+      \ 'Foreign Keys': printf(s:oracle_key_cmd, 'R'),
+      \ 'Indexes': "
+            \SELECT DISTINCT\n\t
+            \N.owner\n\t
+            \N.index_name,\n\t
+            \N.constraint_type\n
+            \" . s:oracle_from . "\n
+            \WHERE\n\t
+            \" . s:oracle_qualify_and_order_by . "N.index_name",
+      \ 'List': 'SELECT * FROM "{schema}"."{table}"',
+      \ 'Primary Keys': printf(s:oracle_key_cmd, 'P'),
+      \ 'References': "
+            \SELECT\n\t
+            \RFRING.owner,\n\t
+            \RFRING.table_name,\n\t
+            \RFRING.column_name\n
+            \FROM all_cons_columns RFRING\n
+            \JOIN all_constraints N\n\t
+            \ON RFRING.constraint_name = N.constraint_name\n
+            \JOIN all_cons_columns RFRD\n\t
+            \ON N.r_constraint_name = RFRD.constraint_name\n
+            \JOIN all_users U\n\t
+            \ON N.owner = U.username\n
+            \WHERE\n\t
+            \N.constraint_type = 'R'\n
+            \AND\n\t
+            \U.common = 'NO'\n
+            \AND\n\t
+            \RFRD.owner = '{schema}'\n
+            \AND\n\t
+            \RFRD.table_name = '{table}'\n
+            \ORDER BY\n\t
+            \RFRING.owner,\n\t
+            \RFRING.table_name,\n\t
+            \RFRING.column_name",
+      \ }
 
 for [helper, query] in items(s:oracle)
-	if helper !=? 'Columns' && helper !=? 'List'
-		let s:oracle[helper] = "SET linesize 4000;\nSET pagesize 4000;\n\nCOLUMN column_name FORMAT a20;\nCOLUMN constraint_type FORMAT a20;\nCOLUMN index_name FORMAT a20;\nCOLUMN owner FORMAT a20;\nCOLUMN table_name FORMAT a20;\n\n".query
-	endif
+   let s:oracle[helper] = "
+      \SET linesize 4000;\n
+      \SET pagesize 4000;\n\n
+      \COLUMN column_name FORMAT a20;\n
+      \COLUMN constraint_type FORMAT a20;\n
+      \COLUMN index_name FORMAT a20;\n
+      \COLUMN owner FORMAT a20;\n
+      \COLUMN table_name FORMAT a20;\n\n
+      \" . query . "\n;"
 endfor
 
 let s:sqlserver_column_summary_query = "


### PR DESCRIPTION
This PR adds first-class support for Oracle databases to this plugin. Here's what works:

* Table helpers.
* Schema detection.
* Table detection.

Here's what isn't working:

* Jumping to foreign keys inside of a `dbout` buffer.

Here's a screenshot:

![Drawer](https://user-images.githubusercontent.com/36409591/98573017-51e63180-2284-11eb-91c4-61ef287f43bd.png)

If there are any requests for edits I'll be happy to take a look. Additionally, I'll get to work on creating a public oracle database so that this PR can be tested.