### PR TITLE
query schemas on pg_catalog.pg_namespace

### DIFF
--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -26,9 +26,9 @@ let s:postgres_foreign_key_query = "
 let s:postgres_list_schema_query = "
     \ SELECT nspname as schema_name
     \ FROM pg_catalog.pg_namespace
-    \ WHERE schema_name !~ '^pg_'
-    \   and pg_catalog.has_schema_privilege(current_user, schema_name, 'USAGE')
-    \ order by schema_name"
+    \ WHERE nspname !~ '^pg_temp_'
+    \   and pg_catalog.has_schema_privilege(current_user, nspname, 'USAGE')
+    \ order by nspname"
 
 let s:postgresql_args = '-A -c "%s"'
 let s:postgresql = {

--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -23,11 +23,18 @@ let s:postgres_foreign_key_query = "
       \       ON ccu.constraint_name = tc.constraint_name
       \ WHERE constraint_type = 'FOREIGN KEY' and kcu.column_name = '{col_name}' LIMIT 1"
 
+let s:postgres_list_schema_query = "
+    \ SELECT nspname as schema_name
+    \ FROM pg_catalog.pg_namespace
+    \ WHERE schema_name !~ '^pg_'
+    \   and pg_catalog.has_schema_privilege(current_user, schema_name, 'USAGE')
+    \ order by schema_name"
+
 let s:postgresql_args = '-A -c "%s"'
 let s:postgresql = {
       \ 'args': s:postgresql_args,
       \ 'foreign_key_query': printf(s:postgresql_args, s:postgres_foreign_key_query),
-      \ 'schemes_query': printf(s:postgresql_args, 'SELECT schema_name FROM information_schema.schemata'),
+      \ 'schemes_query': printf(s:postgresql_args, s:postgres_list_schema_query),
       \ 'schemes_tables_query': printf(s:postgresql_args, 'SELECT table_schema, table_name FROM information_schema.tables'),
       \ 'select_foreign_key_query': 'select * from "%s"."%s" where "%s" = %s',
       \ 'cell_line_number': 2,


### PR DESCRIPTION
Hello,

I love this plugin, I use it for my everyday job and has made me my life easier.
Recently I was creating a new personal user in a Redshift cluster, and found out this:

![image](https://user-images.githubusercontent.com/39086495/105378515-2da3bb00-5c0c-11eb-95ce-7717f2b5218d.png)

Seems that the schemas for the newly created user are missing, checking with my good old user I saw that the schemas in fact were there:

![image](https://user-images.githubusercontent.com/39086495/105378667-562bb500-5c0c-11eb-8efc-02970705217e.png)

Both users has the same permissions and belong to the same groups, so I found out that the query to get the schemas was the one making the difference, it seems a issue related with the `information_schema` and `public` permissions, here is a nice explanation:

https://stackoverflow.com/questions/21781952/how-to-check-if-postgresql-public-schema-exists

In my particular case the problem is that Redshift is based on PostgreSQL 8.0.2, and as the same documentation says, the 
table `information_schema.schemata` only lists the tables that a user owns for versions `<= 9.4`

This PR is to make the schema draw retro/Redshift-compatible, querying to `pg_catalog.pg_namespace` seems to work and is the most similar result of the original query, since it evaluates the privileges of the current user.

I tried to follow the style in the file and added an order to the query for the resulting output 😄 

