### PR TITLE
Add Views to scheme tables query for Oracle

### DIFF
--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -119,7 +119,12 @@ let s:oracle_foreign_key_query = "
       \ AND RFRING.column_name = '{col_name}'"
 let s:oracle_schemes_tables_query = "
       \SELECT T.owner, T.table_name
-      \ FROM all_tables T
+      \ FROM (
+      \ SELECT owner, table_name
+      \ FROM all_tables
+      \ UNION SELECT owner, view_name AS \"table_name\"
+      \ FROM all_views
+      \ ) T
       \ JOIN all_users U ON T.owner = U.username
       \ WHERE U.common = 'NO'
       \ ORDER BY T.table_name"


### PR DESCRIPTION
I have to query from a few Oracle Data Warehouses for work, where all the client accounts only have access to specific views, not to any actual tables. I'd love to use dadbod-ui for this, but the current setup only lists tables under each schema in the drawer.

This patch adds views to the list of tables in the `oracle_schemes_table_query`, similar to how the `postgres` scheme. The `UNION` of `ALL_VIEWS` and `ALL_TABLES` is done in a subquery to simplify the handling of the join on the `ALL_USERS` table.