### PR TITLE
Add scheme for bigquery adapter

### DIFF
--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -141,12 +141,31 @@ let s:oracle = {
       \   'filetype': 'plsql',
       \ }
 
+let s:bigquery_list_schema_query = "SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA;"
+
+let s:bigquery_tables_and_views = "SELECT table_schema, table_name FROM `region-us`.INFORMATION_SCHEMA.SCHEMATA;"
+
+let s:bigquery = {
+      \ 'args': ['-A', '-c'],
+      \ 'schemes_query': s:bigquery_list_schema_query,
+      \ 'schemes_tables_query': s:bigquery_tables_and_views,
+      \ 'cell_line_number': 2,
+      \ 'cell_line_pattern': '^-\++-\+',
+      \ 'parse_results': {results, min_len -> s:results_parser(results[1:], ',', min_len)},
+      \ 'default_scheme': 'public',
+      \ 'layout_flag': '\\x',
+      \ 'quote': 1,
+      \ 'requires_stdin': v:true,
+      \ }
+
+
 let s:schemas = {
       \ 'postgres': s:postgresql,
       \ 'postgresql': s:postgresql,
       \ 'sqlserver': s:sqlserver,
       \ 'mysql': s:mysql,
       \ 'oracle': s:oracle,
+      \ 'bigquery': s:bigquery,
       \ }
 
 if !exists('g:db_adapter_postgres')

--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -141,21 +141,13 @@ let s:oracle = {
       \   'filetype': 'plsql',
       \ }
 
-let s:bigquery_list_schema_query = "SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA;"
-
-let s:bigquery_tables_and_views = "SELECT table_schema, table_name FROM `region-us`.INFORMATION_SCHEMA.SCHEMATA;"
-
 let s:bigquery = {
-      \ 'args': ['-A', '-c'],
-      \ 'schemes_query': s:bigquery_list_schema_query,
-      \ 'schemes_tables_query': s:bigquery_tables_and_views,
-      \ 'cell_line_number': 2,
-      \ 'cell_line_pattern': '^-\++-\+',
+      \ 'args': ['--format=csv'],
+      \ 'schemes_query': "SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA",
+      \ 'schemes_tables_query': "SELECT table_schema, table_name FROM `region-us`.INFORMATION_SCHEMA.TABLES",
       \ 'parse_results': {results, min_len -> s:results_parser(results[1:], ',', min_len)},
-      \ 'default_scheme': 'public',
       \ 'layout_flag': '\\x',
-      \ 'quote': 1,
-      \ 'requires_stdin': v:true,
+      \ 'requires_stdin': v:false,
       \ }
 
 

--- a/autoload/db_ui/table_helpers.vim
+++ b/autoload/db_ui/table_helpers.vim
@@ -9,6 +9,12 @@ let s:basic_constraint_query = "
       \     JOIN information_schema.constraint_column_usage AS ccu\n
       \       ON ccu.constraint_name = tc.constraint_name\n"
 
+let s:bigquery = {
+      \ 'List': 'select * from {optional_schema}{table} LIMIT 200',
+      \ 'Columns': "select * from {schema}.INFORMATION_SCHEMA.COLUMNS where table_name='{table}'",
+      \ }
+
+
 let s:postgres = {
       \ 'List': 'select * from {optional_schema}"{table}" LIMIT 200',
       \ 'Columns': "select * from information_schema.columns where table_name='{table}' and table_schema='{schema}'",
@@ -176,6 +182,7 @@ let s:sqlserver = {
 \   }
 
 let s:helpers = {
+      \ 'bigquery': s:bigquery,
       \ 'postgresql': s:postgres,
       \ 'mysql': s:mysql,
       \ 'oracle': s:oracle,


### PR DESCRIPTION
## Summary

- This PR adds support for `bigquery://` adapters, based on an implementation here: https://github.com/mbhynes/vim-dadbod/pull/1
