### PR TITLE
feat(ui): customize dbout winheight

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ What should be the drawer width when opened. Default is `40`.
 let g:db_ui_winwidth = 30
 ```
 
+### Output height
+
+What should be the db output window height. Default is `20`.
+
+```vimL
+let g:db_ui_dbout_winheight = 40
+```
+
 ### Default query
 
 **DEPRECATED**: Use [Table helpers](#table-helpers) instead.

--- a/plugin/db_ui.vim
+++ b/plugin/db_ui.vim
@@ -5,6 +5,7 @@ let g:loaded_dbui = 1
 
 let g:db_ui_notification_width = get(g:, 'db_ui_notification_width', 40)
 let g:db_ui_winwidth = get(g:, 'db_ui_winwidth', 40)
+let g:db_ui_dbout_winheight = get(g:, 'db_ui_dbout_winheight', 20)
 let g:db_ui_win_position = get(g:, 'db_ui_win_position', 'left')
 let g:db_ui_default_query = get(g:, 'db_ui_default_query', 'SELECT * from "{table}" LIMIT 200;')
 let g:db_ui_save_location = get(g:, 'db_ui_save_location', '~/.local/share/db_ui')
@@ -112,6 +113,7 @@ augroup dbui
   autocmd BufReadPost *.dbout nested call db_ui#save_dbout(expand('<afile>'))
   autocmd FileType dbout setlocal foldmethod=expr foldexpr=db_ui#dbout#foldexpr(v:lnum) | normal!zo
   autocmd FileType dbout,dbui autocmd BufEnter,WinEnter <buffer> stopinsert
+  autocmd FileType dbout execute ':horizontal resize ' . g:db_ui_dbout_winheight
 augroup END
 
 command! DBUI call db_ui#open('<mods>')


### PR DESCRIPTION
Often the time, the query result is big. It would be nice if we can customize the window height of the dbout buffer