### PR TITLE
Respect empty background for notifications

### DIFF
--- a/autoload/db_ui/notifications.vim
+++ b/autoload/db_ui/notifications.vim
@@ -166,32 +166,23 @@ function! s:setup_colors() abort
   let normal_bg = ''
   let warning_bg = synIDattr(hlID('WarningMsg'), 'bg')
   let warning_fg = synIDattr(hlID('WarningMsg'), 'fg')
-  if empty(warning_bg)
-    let warning_bg = warning_fg
-    let warning_fg = '#FFFFFF'
   endif
 
   let error_bg = synIDattr(hlID('Error'), 'bg')
   let error_fg = synIDattr(hlID('Error'), 'fg')
-  if empty(error_bg)
-    let error_bg = error_fg
-    let error_fg = '#FFFFFF'
   endif
 
   let normal_bg = synIDattr(hlID('Normal'), 'bg')
   let normal_fg = synIDattr(hlID('Normal'), 'fg')
-  if empty(normal_bg)
-    let normal_bg = normal_fg
-    let normal_fg = '#FFFFFF'
   endif
 
-  call s:set_hl('NotificationInfo', normal_bg, normal_fg)
+  call s:set_hl('NotificationInfo', normal_fg, normal_bg)
   call s:set_hl('NotificationError', error_fg, error_bg)
   call s:set_hl('NotificationWarning', warning_fg, warning_bg)
 
   call s:set_hl('EchoNotificationInfo', normal_fg, 'NONE')
-  call s:set_hl('EchoNotificationError', error_bg, 'NONE')
-  call s:set_hl('EchoNotificationWarning', warning_bg, 'NONE')
+  call s:set_hl('EchoNotificationError', error_fg, 'NONE')
+  call s:set_hl('EchoNotificationWarning', warning_fg, 'NONE')
 endfunction
 
 function! s:get_pos(pos, width) abort


### PR DESCRIPTION
Hi, thanks for an awesome plugin.

I'm using a dark colorscheme with a transparent background. This caused me a problem where text on Info notifications wasn't readable. The reason was lines 183-185 in the original file.

My background was transparent (empty), meaning it got set to my foreground color (white as I'm running a dark theme), and then the background got set to white, making the text unreadable.

This change ensures that text always remains readable, as it's always either using default values or values that are set by the theme and so must be readable.

This change will make the Info notification a little less fancy, since the fg and bg colors aren't swapped, but it ensures that whatever the settings are, the text is always readable. 