### PR TITLE
fix(save-url): no resolve before save

### DIFF
--- a/autoload/db_ui.vim
+++ b/autoload/db_ui.vim
@@ -366,7 +366,7 @@ function! s:dbui.add_if_not_exists(name, url, source) abort
     return db_ui#notifications#warning(printf('Warning: Duplicate connection name "%s" in "%s" source. First one added has precedence.', a:name, a:source))
   endif
   return add(self.dbs_list, {
-        \ 'name': a:name, 'url': db#resolve(a:url), 'source': a:source, 'key_name': printf('%s_%s', a:name, a:source)
+        \ 'name': a:name, 'url': a:url, 'source': a:source, 'key_name': printf('%s_%s', a:name, a:source)
         \ })
 endfunction
 

--- a/autoload/db_ui/connections.vim
+++ b/autoload/db_ui/connections.vim
@@ -43,20 +43,20 @@ endfunction
 
 function! s:connections.add_full_url() abort
   let url = ''
+  let url_resolved = ''
 
   try
-    let url = db#resolve(db_ui#utils#input('Enter connection url: ', url))
-    call db#url#parse(url)
+    let url = db_ui#utils#input('Enter connection url: ', url)
+    let url_resolved = db#resolve(url)
+    call db#url#parse(url_resolved)
   catch /.*/
     return db_ui#notifications#error(v:exception)
   endtry
-
   try
-    let name = self.enter_db_name(url)
+    let name = self.enter_db_name(url_resolved)
   catch /.*/
     return db_ui#notifications#error(v:exception)
   endtry
-
   return self.save(name, url)
 endfunction
 
@@ -78,8 +78,9 @@ function! s:connections.rename(db) abort
 
   let url = entry.url
   try
-    let url = db#resolve(db_ui#utils#input('Edit connection url for "'.entry.name.'": ', url))
-    call db#url#parse(url)
+    let url_new = db_ui#utils#input('Edit connection url for "'.entry.name.'": ', url)
+    let url_resolved = db#resolve(url_new)
+    call db#url#parse(url_new)
   catch /.*/
     return db_ui#notifications#error(v:exception)
   endtry
@@ -96,7 +97,7 @@ function! s:connections.rename(db) abort
   endtry
 
   call remove(connections, idx)
-  let connections = insert(connections, {'name': name, 'url': url }, idx)
+  let connections = insert(connections, {'name': name, 'url': url_new }, idx)
   return self.write(connections)
 endfunction
 


### PR DESCRIPTION
Right now, I cannot use dadbod-ssh with ui because whenever I save an URL, the saved URL is resolved before saving. With ssh adapter, the url points to a localhost:7000 after resolving (or so). This is the URL that is saved in connection.json.

Then when I close nvim and try to reopen connection to the database, the local port (7000) is closed. dadbod-ui is trying to open it without opening ssh tunnel because url is not saved with the ssh:/ prefix (as it is resolved).

Here I removed the db#resolved from the saved url and from the added connections.

I probably missed something as they were probably there for a reason. In this case, please feel free to tell me what I'm missing for this to be accepted.

However, I don't understand why dadbod-ui has his own version of adapters. vim-dadbod let's you write some so why not adding adapters directly to vim-dadbod? Please enlighten me on the matter

Disclaimer : I've never written anything in vimscript