### PR TITLE
[Feature] Add option to automatically expand query results

### DIFF
--- a/doc/dadbod-ui.txt
+++ b/doc/dadbod-ui.txt
@@ -684,6 +684,13 @@ g:db_ui_use_nerd_fonts
 
 		Default value: `0`
 
+					      *g:db_ui_expand_query_results*
+g:db_ui_expand_query_results
+		Set this to `1` to automatically expand query results in the
+		dbout buffer.
+
+		Default value: `0`
+
 					      *g:db_ui_show_help*
 g:db_ui_show_help
 		When set to `0`, hides `Press ? for help` from the DBUI

--- a/plugin/db_ui.vim
+++ b/plugin/db_ui.vim
@@ -17,6 +17,7 @@ let g:db_ui_table_helpers = get(g:, 'db_ui_table_helpers', {})
 let g:db_ui_auto_execute_table_helpers = get(g:, 'db_ui_auto_execute_table_helpers', 0)
 let g:db_ui_show_help = get(g:, 'db_ui_show_help', 1)
 let g:db_ui_use_nerd_fonts = get(g:, 'db_ui_use_nerd_fonts', 0)
+let g:db_ui_expand_query_results = get(g:, 'db_ui_expand_query_results', 0)
 let g:db_ui_execute_on_save = get(g:, 'db_ui_execute_on_save', 1)
 let g:db_ui_force_echo_notifications = get(g:, 'db_ui_force_echo_notifications', 0)
 let g:db_ui_use_nvim_notify = get(g:, 'db_ui_use_nvim_notify', 0)
@@ -111,7 +112,9 @@ augroup dbui
   autocmd!
   autocmd BufRead,BufNewFile *.dbout set filetype=dbout
   autocmd BufReadPost *.dbout nested call db_ui#save_dbout(expand('<afile>'))
-  autocmd FileType dbout setlocal foldmethod=expr foldexpr=db_ui#dbout#foldexpr(v:lnum) | normal!zo
+  if !g:db_ui_expand_query_results
+    autocmd FileType dbout setlocal foldmethod=expr foldexpr=db_ui#dbout#foldexpr(v:lnum) | normal!zo
+  endif
   autocmd FileType dbout,dbui autocmd BufEnter,WinEnter <buffer> stopinsert
 augroup END
 


### PR DESCRIPTION
Currently there's not an option to automatically expand the sql result in the dbout buffer. I tried setting the fold method to manual for "dbout" but that didn't work:
```vim
autocmd FileType dbout set foldmethod=manual
```
Hence I added an option g:db_ui_expand_query_results that adds prevents automatic folding and I updated the documentation accordingly.