### PR TITLE
Add support for vim-dadbod BiqQuery adapter

### DIFF
--- a/autoload/db_ui/table_helpers.vim
+++ b/autoload/db_ui/table_helpers.vim
@@ -9,6 +9,12 @@ let s:basic_constraint_query = "
       \     JOIN information_schema.constraint_column_usage AS ccu\n
       \       ON ccu.constraint_name = tc.constraint_name\n"
 
+let s:bigquery = {
+      \ 'List': 'select * from {optional_schema}{table} LIMIT 200',
+      \ 'Columns': "select * from {schema}.INFORMATION_SCHEMA.COLUMNS where table_name='{table}'",
+      \ }
+
+
 let s:postgres = {
       \ 'List': 'select * from {optional_schema}"{table}" LIMIT 200',
       \ 'Columns': "select * from information_schema.columns where table_name='{table}' and table_schema='{schema}'",
@@ -176,6 +182,7 @@ let s:sqlserver = {
 \   }
 
 let s:helpers = {
+      \ 'bigquery': s:bigquery,
       \ 'postgresql': s:postgres,
       \ 'mysql': s:mysql,
       \ 'oracle': s:oracle,


### PR DESCRIPTION
## Summary

- This PR adds support for BigQuery, an OLAP database provided by Google, as a BigQuery adapter was recently added to `vim-dadbod` with https://github.com/tpope/vim-dadbod/pull/125
- This PR adds functionality for `bigquery:://` connections

## Notes for Reviewers

### Dependencies for Running / Testing
- The new adapter depends on having the `bq` CLI provided by the google cloud CLI is in the user's `$PATH`, configured to authenticate with some google identity credentials
- As such, running & testing this requires installing the `gcloud` CLI ([installation instructions](https://cloud.google.com/sdk/docs/install)) and having a google account. (Users interested in using `vim-dadbod-ui` for running queries against BigQuery will almost surely have `gcloud` and `bq` installed already)

### Added variable
- I've added a global variable `g:db_adapter_bigquery_region`, to allow users to parameterize the schema query against the `INFORMATION_SCHEMA.TABLES` (the default is `region-us`)
```vim
let s:bigquery_schema_tables_query = printf("
      \ SELECT table_schema, table_name
      \ FROM `%s`.INFORMATION_SCHEMA.TABLES
      \ ", g:db_adapter_bigquery_region)
```


### Example Screenshot
![vim-dadbod-ui2](https://user-images.githubusercontent.com/10452129/222333881-f3b7b061-5cea-48e5-8821-3e2a6d3bb710.gif)