### PR TITLE
Remove cursorline option

### DIFF
--- a/autoload/db_ui/drawer.vim
+++ b/autoload/db_ui/drawer.vim
@@ -35,7 +35,7 @@ function! s:drawer.open(...) abort
     silent! exe 'vertical '.win_pos.' new dbui'
     silent! exe 'vertical '.win_pos.' resize '.g:db_ui_winwidth
   endif
-  setlocal filetype=dbui buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap cursorline nospell nomodifiable winfixwidth nonumber norelativenumber signcolumn=no
+  setlocal filetype=dbui buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap nospell nomodifiable winfixwidth nonumber norelativenumber signcolumn=no
 
   call self.render()
   nnoremap <silent><buffer> <Plug>(DBUI_SelectLine) :call <sid>method('toggle_line', 'edit')<CR>

--- a/autoload/db_ui/query.vim
+++ b/autoload/db_ui/query.vim
@@ -164,7 +164,7 @@ function! s:query.setup_buffer(db, opts, buffer_name, was_single_win) abort
   endif
 
   if &filetype !=? a:db.filetype || !is_existing_buffer
-    silent! exe 'setlocal filetype='.a:db.filetype.' nolist noswapfile nowrap cursorline nospell modifiable'
+    silent! exe 'setlocal filetype='.a:db.filetype.' nolist noswapfile nowrap nospell modifiable'
   endif
   let is_sql = &filetype ==? a:db.filetype
   nnoremap <silent><buffer><Plug>(DBUI_EditBindParameters) :call <sid>method('edit_bind_parameters')<CR>


### PR DESCRIPTION
I feel like this should not be forced on the buffers created by this plugin, and should instead be set up by the user in their configs. I don't use this option, and have to use a major hack to turn it off:

```lua
vim.api.nvim_create_autocmd("BufEnter", {
    pattern = "*-query-*",
    group = vim.api.nvim_create_augroup("DadbodCursorlineHack", { clear = true }),
    callback = function()
        vim.defer_fn(function()
            vim.opt_local.cursorline = false
        end, 50)
    end,
    desc = "Disable cursorline in dbui",
})
```

Closes #217 