### PR TITLE
[BUGFIX] enable other BQ regions to get schemas

### DIFF
--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -154,7 +154,9 @@ if !exists('g:db_adapter_bigquery_region')
   let g:db_adapter_bigquery_region = 'region-us'
 endif
 
-let s:bigquery_schemas_query = "SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA" 
+let s:bigquery_schemas_query = printf("
+      \ SELECT schema_name FROM `%s`.INFORMATION_SCHEMA.SCHEMATA
+      \ ", g:db_adapter_bigquery_region) 
 
 let s:bigquery_schema_tables_query = printf("
       \ SELECT table_schema, table_name


### PR DESCRIPTION
- BigQuery defaults to the US region when querying `INFORMATION_SCHEMA.SCHEMATA` tables
- If the datasets/tables are not in the US region this query returns nothing and the schema section is empty
- Included the db_adapter_bigquery_reion in the query so that it will return the correct datasets and tables