### PR TITLE
Added Support for Redshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,12 +265,12 @@ If you don't want any mappings to be added, add this to vimrc:
 let g:db_ui_disable_mappings = 1
 ```
 
-## Use redshift database
+## View tables with redshift instead of postgres
 Amazon Redshift is a modified version of postgres.
 They both work with vim-dadbod-ui in a very similar way but there are subtle differences.
 If you need to use redshift, add this to vimrc:
 ```vimL
-let g:db_ui_use_redshift = 1
+let g:db_ui_use_postgres_views = 0
 ```
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -265,10 +265,10 @@ If you don't want any mappings to be added, add this to vimrc:
 let g:db_ui_disable_mappings = 1
 ```
 
-## View tables with redshift instead of postgres
-Amazon Redshift is a modified version of postgres.
-They both work with vim-dadbod-ui in a very similar way but there are subtle differences.
-If you need to use redshift, add this to vimrc:
+## Toggle showing postgres views in the drawer
+If you don't want to see any views in the drawer, add this to vimrc:
+This option must be disabled (set to 0) for Redshift.
+
 ```vimL
 let g:db_ui_use_postgres_views = 0
 ```

--- a/README.md
+++ b/README.md
@@ -265,6 +265,14 @@ If you don't want any mappings to be added, add this to vimrc:
 let g:db_ui_disable_mappings = 1
 ```
 
+## Use redshift database
+Amazon Redshift is a modified version of postgres.
+They both work with vim-dadbod-ui in a very similar way but there are subtle differences.
+If you need to use redshift, add this to vimrc:
+```vimL
+let g:db_ui_use_redshift = 1
+```
+
 ## TODO
 
 * [ ] Test with more db types

--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -34,7 +34,7 @@ let s:postgres_list_schema_query = "
     \   and pg_catalog.has_schema_privilege(current_user, nspname, 'USAGE')
     \ order by nspname"
 
-if !empty(g:db_ui_use_redshift)
+if empty(g:db_ui_use_postgres_views)
   let postgres_tables_and_views = "
         \ SELECT table_schema, table_name FROM information_schema.tables ;"
 else

--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -34,9 +34,16 @@ let s:postgres_list_schema_query = "
     \   and pg_catalog.has_schema_privilege(current_user, nspname, 'USAGE')
     \ order by nspname"
 
-let s:postgres_tables_and_views = "
-      \ SELECT table_schema, table_name FROM information_schema.tables UNION ALL
-      \ select schemaname, matviewname from pg_matviews;"
+if !empty(g:db_ui_use_redshift)
+  let postgres_tables_and_views = "
+        \ SELECT table_schema, table_name FROM information_schema.tables ;"
+else
+  let postgres_tables_and_views = "
+        \ SELECT table_schema, table_name FROM information_schema.tables UNION ALL
+        \ select schemaname, matviewname from pg_matviews;"
+endif
+let s:postgres_tables_and_views = postgres_tables_and_views
+
 let s:postgresql = {
       \ 'args': ['-A', '-c'],
       \ 'foreign_key_query': s:postgres_foreign_key_query,

--- a/autoload/db_ui/table_helpers.vim
+++ b/autoload/db_ui/table_helpers.vim
@@ -15,7 +15,7 @@ let s:bigquery = {
       \ }
 
 
-let postgres = {
+let s:postgres = {
       \ 'List': 'select * from {optional_schema}"{table}" LIMIT 200',
       \ 'Columns': "select * from information_schema.columns where table_name='{table}' and table_schema='{schema}'",
       \ 'Indexes': "SELECT * FROM pg_indexes where tablename='{table}' and schemaname='{schema}'",

--- a/autoload/db_ui/table_helpers.vim
+++ b/autoload/db_ui/table_helpers.vim
@@ -15,14 +15,26 @@ let s:bigquery = {
       \ }
 
 
-let s:postgres = {
-      \ 'List': 'select * from {optional_schema}"{table}" LIMIT 200',
-      \ 'Columns': "select * from information_schema.columns where table_name='{table}' and table_schema='{schema}'",
-      \ 'Indexes': "SELECT * FROM pg_indexes where tablename='{table}' and schemaname='{schema}'",
-      \ 'Foreign Keys': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
-      \ 'References': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand ccu.table_name = '{table}'\nand tc.table_schema = '{schema}'",
-      \ 'Primary Keys': s:basic_constraint_query."WHERE constraint_type = 'PRIMARY KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
-      \ }
+if !empty(g:db_ui_use_redshift)
+  let postgres = {
+        \ 'List': 'select * from {optional_schema}"{table}" LIMIT 200',
+        \ 'Columns': "SELECT column_name from information_schema.columns WHERE table_name='{table}' AND table_schema='{schema}'",
+        \ 'Indexes': "SELECT * FROM pg_indexes where tablename='{table}' and schemaname='{schema}'",
+        \ 'Foreign Keys': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
+        \ 'References': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand ccu.table_name = '{table}'\nand tc.table_schema = '{schema}'",
+        \ 'Primary Keys': s:basic_constraint_query."WHERE constraint_type = 'PRIMARY KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
+        \ }
+else
+  let postgres = {
+        \ 'List': 'select * from {optional_schema}"{table}" LIMIT 200',
+        \ 'Columns': "select * from information_schema.columns where table_name='{table}' and table_schema='{schema}'",
+        \ 'Indexes': "SELECT * FROM pg_indexes where tablename='{table}' and schemaname='{schema}'",
+        \ 'Foreign Keys': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
+        \ 'References': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand ccu.table_name = '{table}'\nand tc.table_schema = '{schema}'",
+        \ 'Primary Keys': s:basic_constraint_query."WHERE constraint_type = 'PRIMARY KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
+        \ }
+endif
+let s:postgres = postgres
 
 let s:sqlite = {
       \ 'List': g:db_ui_default_query,

--- a/autoload/db_ui/table_helpers.vim
+++ b/autoload/db_ui/table_helpers.vim
@@ -14,27 +14,14 @@ let s:bigquery = {
       \ 'Columns': "select * from {schema}.INFORMATION_SCHEMA.COLUMNS where table_name='{table}'",
       \ }
 
-
-if !empty(g:db_ui_use_redshift)
-  let postgres = {
-        \ 'List': 'select * from {optional_schema}"{table}" LIMIT 200',
-        \ 'Columns': "SELECT column_name from information_schema.columns WHERE table_name='{table}' AND table_schema='{schema}'",
-        \ 'Indexes': "SELECT * FROM pg_indexes where tablename='{table}' and schemaname='{schema}'",
-        \ 'Foreign Keys': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
-        \ 'References': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand ccu.table_name = '{table}'\nand tc.table_schema = '{schema}'",
-        \ 'Primary Keys': s:basic_constraint_query."WHERE constraint_type = 'PRIMARY KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
-        \ }
-else
-  let postgres = {
-        \ 'List': 'select * from {optional_schema}"{table}" LIMIT 200',
-        \ 'Columns': "select * from information_schema.columns where table_name='{table}' and table_schema='{schema}'",
-        \ 'Indexes': "SELECT * FROM pg_indexes where tablename='{table}' and schemaname='{schema}'",
-        \ 'Foreign Keys': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
-        \ 'References': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand ccu.table_name = '{table}'\nand tc.table_schema = '{schema}'",
-        \ 'Primary Keys': s:basic_constraint_query."WHERE constraint_type = 'PRIMARY KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
-        \ }
-endif
-let s:postgres = postgres
+let postgres = {
+      \ 'List': 'select * from {optional_schema}"{table}" LIMIT 200',
+      \ 'Columns': "select * from information_schema.columns where table_name='{table}' and table_schema='{schema}'",
+      \ 'Indexes': "SELECT * FROM pg_indexes where tablename='{table}' and schemaname='{schema}'",
+      \ 'Foreign Keys': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
+      \ 'References': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand ccu.table_name = '{table}'\nand tc.table_schema = '{schema}'",
+      \ 'Primary Keys': s:basic_constraint_query."WHERE constraint_type = 'PRIMARY KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
+      \ }
 
 let s:sqlite = {
       \ 'List': g:db_ui_default_query,

--- a/autoload/db_ui/table_helpers.vim
+++ b/autoload/db_ui/table_helpers.vim
@@ -14,6 +14,7 @@ let s:bigquery = {
       \ 'Columns': "select * from {schema}.INFORMATION_SCHEMA.COLUMNS where table_name='{table}'",
       \ }
 
+
 let postgres = {
       \ 'List': 'select * from {optional_schema}"{table}" LIMIT 200',
       \ 'Columns': "select * from information_schema.columns where table_name='{table}' and table_schema='{schema}'",

--- a/doc/dadbod-ui.txt
+++ b/doc/dadbod-ui.txt
@@ -716,8 +716,8 @@ g:db_ui_force_echo_notifications
 
 					     *g:db_ui_use_postgres_views*
 g:db_ui_use_postgres_views
-    Postgres database shows tables within schemas nicely. To show
-    tables nicely within Redshift set this value to 0.
+    Toggle showing postgres views in the drawer.
+    This option must be disabled (set to 0) for Redshift.
 
     Default value: 1
 

--- a/doc/dadbod-ui.txt
+++ b/doc/dadbod-ui.txt
@@ -714,8 +714,7 @@ g:db_ui_force_echo_notifications
 
 		Default value: `0`
 
-					     g:db_ui_use_postgres_views
-
+					     *g:db_ui_use_postgres_views*
 g:db_ui_use_postgres_views
     Postgres database shows tables within schemas nicely. To show
     tables nicely within Redshift set this value to 0.

--- a/doc/dadbod-ui.txt
+++ b/doc/dadbod-ui.txt
@@ -714,6 +714,14 @@ g:db_ui_force_echo_notifications
 
 		Default value: `0`
 
+					     g:db_ui_use_postgres_views
+
+g:db_ui_use_postgres_views
+    Postgres database shows tables within schemas nicely. To show
+    tables nicely within Redshift set this value to 0.
+
+    Default value: 1
+
 					      *g:db_ui_use_nvim_notify*
 g:db_ui_use_nvim_notify
 		Use Neovim's `vim.notify` API for notifications.

--- a/plugin/db_ui.vim
+++ b/plugin/db_ui.vim
@@ -3,6 +3,7 @@ if exists('g:loaded_dbui')
 endif
 let g:loaded_dbui = 1
 
+let g:db_ui_use_postgres_views = get(g:, 'db_ui_use_postgres_views', 1)
 let g:db_ui_notification_width = get(g:, 'db_ui_notification_width', 40)
 let g:db_ui_winwidth = get(g:, 'db_ui_winwidth', 40)
 let g:db_ui_win_position = get(g:, 'db_ui_win_position', 'left')


### PR DESCRIPTION
Pull request adds support for a `vim.g.db_ui_use_redshift` flag that you can add to init.lua or, in my case, plug-dadbod.lua. New code just checks for the existence of this new flag and if it is not present or is set to 0 it runs the original code. 

I have also updated the README with the vimL way of adding this flag.

This would close #131 