### PR TITLE
Show Full Minutes and Seconds on Query Execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,11 +273,12 @@ This option must be disabled (set to 0) for Redshift.
 let g:db_ui_use_postgres_views = 0
 ```
 
-## Show full minutes and seconds when query executes
-If you want to see full minutes and seconds for query run time, add this to vimrc:
+## Disable builtin progress bar
+If you want to utilize *DBExecutePre or *DBExecutePost to make your own progress bar
+or if you want to disable the progress entirely set to 1.
 
 ```vimL
-let g:db_ui_query_execute_full_minutes_and_seconds = 1
+let g:db_ui_disable_progress_bar = 1
 ```
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -273,6 +273,13 @@ This option must be disabled (set to 0) for Redshift.
 let g:db_ui_use_postgres_views = 0
 ```
 
+## Show full minutes and seconds when query executes
+If you want to see full minutes and seconds for query run time, add this to vimrc:
+
+```vimL
+let g:db_ui_query_execute_full_minutes_and_seconds = 1
+```
+
 ## TODO
 
 * [ ] Test with more db types

--- a/autoload/db_ui/dbout.vim
+++ b/autoload/db_ui/dbout.vim
@@ -1,5 +1,5 @@
 function! db_ui#dbout#jump_to_foreign_table() abort
-  let db_url = b:db.db_url
+  let db_url = db_ui#resolve(b:db)
   let parsed = db#url#parse(db_url)
   let scheme = db_ui#schemas#get(parsed.scheme)
   if empty(scheme)
@@ -229,8 +229,36 @@ function! s:progress_tick(progress, timer) abort
   if a:progress.icon_counter > 3
     let a:progress.icon_counter = 0
   endif
-  let secs = string(a:progress.counter * 0.001).'s'
-  let content = ' '.s:progress_icons[a:progress.icon_counter].' Execute query - '.secs
+  if !empty(g:db_ui_use_full_minutes_and_seconds)
+    let secs = a:progress.counter * 0.001
+    let minutes = string(floor(secs / 60))
+    let formattedminutes = substitute(minutes, '\.0$', '', '')
+    let seconds = string(((fmod(secs / 60, 1) * 60) / 100) * 100)
+    if formattedminutes > 0
+      if formattedminutes < 2
+        if seconds < 10
+          let content = ' '.s:progress_icons[a:progress.icon_counter].' Execute query ---- '.formattedminutes.' minute '.seconds.' seconds '
+        else
+          let content = ' '.s:progress_icons[a:progress.icon_counter].' Execute query --- '.formattedminutes.' minute '.seconds.' seconds '
+        endif
+      else
+        if seconds < 10
+          let content = ' '.s:progress_icons[a:progress.icon_counter].' Execute query --- '.formattedminutes.' minutes '.seconds.' seconds '
+        else
+          let content = ' '.s:progress_icons[a:progress.icon_counter].' Execute query -- '.formattedminutes.' minutes '.seconds.' seconds '
+        endif
+      endif
+    else
+      if seconds < 10
+        let content = ' '.s:progress_icons[a:progress.icon_counter].' Execute query ------------- '.seconds.' seconds'
+      else
+        let content = ' '.s:progress_icons[a:progress.icon_counter].' Execute query ------------ '.seconds.' seconds'
+      endif
+    endif
+  else
+    let secs = string(a:progress.counter * 0.001).'s'
+    let content = ' '.s:progress_icons[a:progress.icon_counter].' Execute query - '.secs
+  endif
   if has('nvim')
     call nvim_buf_set_lines(a:progress.buf, 0, -1, v:false, [content])
   else
@@ -241,10 +269,17 @@ endfunction
 
 function! s:progress_winpos(win)
   let pos = win_screenpos(a:win)
-  return [
-        \ pos[0] + (winheight(a:win) / 2),
-        \ pos[1] + (winwidth(a:win) / 2) - 12,
-        \ ]
+  if !empty(g:db_ui_use_full_minutes_and_seconds)
+    return [
+          \ pos[0] + (winheight(a:win) / 2),
+          \ pos[1] + (winwidth(a:win) / 2) - (winwidth(a:win) / 5),
+          \ ]
+  else
+    return [
+          \ pos[0] + (winheight(a:win) / 2),
+          \ pos[1] + (winwidth(a:win) / 2) - 12,
+          \ ]
+  endif
 endfunction
 
 function! s:progress_hide(...) abort
@@ -281,18 +316,33 @@ function! s:progress_show_neovim(path) abort
   let progress = copy(s:progress)
   let progress.outwin = outwin
   let progress.buf = nvim_create_buf(v:false, v:true)
-  call nvim_buf_set_lines(progress.buf, 0, -1, v:false, ['| Execute query - 0.0s'])
+  if !empty(g:db_ui_use_full_minutes_and_seconds)
+    call nvim_buf_set_lines(progress.buf, 0, -1, v:false, ['| Execute query --- 0 minutes 0 seconds'])
+  else
+    call nvim_buf_set_lines(progress.buf, 0, -1, v:false, ['| Execute query - 0.0s'])
+  endif
   let [row, col] = s:progress_winpos(outwin)
-  let opts = {
-        \ 'relative': 'editor',
-        \ 'width': 24,
-        \ 'height': 1,
-        \ 'row': row - 2,
-        \ 'col': col,
-        \ 'focusable': v:false,
-        \ 'style': 'minimal'
-        \ }
-
+  if !empty(g:db_ui_use_full_minutes_and_seconds)
+    let opts = {
+          \ 'relative': 'editor',
+          \ 'width': 43,
+          \ 'height': 1,
+          \ 'row': row - 2,
+          \ 'col': col,
+          \ 'focusable': v:false,
+          \ 'style': 'minimal'
+          \ }
+  else
+    let opts = {
+          \ 'relative': 'editor',
+          \ 'width': 24,
+          \ 'height': 1,
+          \ 'row': row - 2,
+          \ 'col': col,
+          \ 'focusable': v:false,
+          \ 'style': 'minimal'
+          \ }
+  endif
   if has('nvim-0.5')
     let opts.border = 'rounded'
   endif

--- a/autoload/db_ui/dbout.vim
+++ b/autoload/db_ui/dbout.vim
@@ -1,5 +1,5 @@
 function! db_ui#dbout#jump_to_foreign_table() abort
-  let db_url = db_ui#resolve(b:db)
+  let db_url = b:db.db_url
   let parsed = db#url#parse(db_url)
   let scheme = db_ui#schemas#get(parsed.scheme)
   if empty(scheme)

--- a/autoload/db_ui/dbout.vim
+++ b/autoload/db_ui/dbout.vim
@@ -292,6 +292,7 @@ function! s:progress_show_neovim(path) abort
         \ 'focusable': v:false,
         \ 'style': 'minimal'
         \ }
+
   if has('nvim-0.5')
     let opts.border = 'rounded'
   endif

--- a/doc/dadbod-ui.txt
+++ b/doc/dadbod-ui.txt
@@ -721,10 +721,11 @@ g:db_ui_use_postgres_views
 
     Default value: 1
 
-					     *g:db_ui_query_execute_full_minutes_and_seconds*
-g:db_ui_query_execute_full_minutes_and_seconds
-    By default query run time is shown in seconds only.
-    To show full minutes and seconds on query execute set this value to 1.
+					     *g:db_ui_disable_progress_bar*
+g:db_ui_disable_progress_bar
+    Toggle query execution progress bar.
+    This option is available to prevent conflict with a custom progress bar
+    or if you want to disable the progress entirely set to 1.
 
     Default value: 0
 

--- a/doc/dadbod-ui.txt
+++ b/doc/dadbod-ui.txt
@@ -721,6 +721,13 @@ g:db_ui_use_postgres_views
 
     Default value: 1
 
+					     *g:db_ui_query_execute_full_minutes_and_seconds*
+g:db_ui_query_execute_full_minutes_and_seconds
+    By default query run time is shown in seconds only.
+    To show full minutes and seconds on query execute set this value to 1.
+
+    Default value: 0
+
 					      *g:db_ui_use_nvim_notify*
 g:db_ui_use_nvim_notify
 		Use Neovim's `vim.notify` API for notifications.

--- a/plugin/db_ui.vim
+++ b/plugin/db_ui.vim
@@ -3,6 +3,7 @@ if exists('g:loaded_dbui')
 endif
 let g:loaded_dbui = 1
 
+let g:db_ui_query_execute_full_minutes_and_seconds = get(g:, 'db_ui_query_execute_full_minutes_and_seconds', 0)
 let g:db_ui_use_postgres_views = get(g:, 'db_ui_use_postgres_views', 1)
 let g:db_ui_notification_width = get(g:, 'db_ui_notification_width', 40)
 let g:db_ui_winwidth = get(g:, 'db_ui_winwidth', 40)

--- a/plugin/db_ui.vim
+++ b/plugin/db_ui.vim
@@ -3,7 +3,7 @@ if exists('g:loaded_dbui')
 endif
 let g:loaded_dbui = 1
 
-let g:db_ui_query_execute_full_minutes_and_seconds = get(g:, 'db_ui_query_execute_full_minutes_and_seconds', 0)
+let g:db_ui_disable_progress_bar = get(g:, 'db_ui_disable_progress_bar', 0)
 let g:db_ui_use_postgres_views = get(g:, 'db_ui_use_postgres_views', 1)
 let g:db_ui_notification_width = get(g:, 'db_ui_notification_width', 40)
 let g:db_ui_winwidth = get(g:, 'db_ui_winwidth', 40)


### PR DESCRIPTION
Another customization I've made is to show full minutes and seconds on query execute. This would be a completely new feature but it's something I use so I thought I'd put it into a pull request in case you'd like to merge it.

All it does is adjust the screen to show the full time of your query rather than only the seconds.

<details>

<Summary> Examples:</Summary>

Less than 10 seconds into the query:
![LessThan10S](https://github.com/kristijanhusak/vim-dadbod-ui/assets/59935328/d336624c-1b6b-46fb-afdf-b56643836e9e)

Less than 1 minute into the query:
![LessThan1M](https://github.com/kristijanhusak/vim-dadbod-ui/assets/59935328/a17c1cce-4eb1-4315-852e-c677041ce957)

Less than 1 minute and 10 seconds into the query:
![LessThan1M10S](https://github.com/kristijanhusak/vim-dadbod-ui/assets/59935328/706ae9bf-4b77-4765-84d4-9a29db8a5506)

Less than 2 minutes into the query:
![LessThan2M](https://github.com/kristijanhusak/vim-dadbod-ui/assets/59935328/7996902b-0b89-4679-bb60-330e1e2ba1e0)

Less than 2 minutes and 10 seconds into the query:
![LessThan2M10S](https://github.com/kristijanhusak/vim-dadbod-ui/assets/59935328/ee61da81-2453-4248-bd33-f5efc17e5777)

More than 2 minutes and 10 seconds into the query:
![MoreThan2M10S](https://github.com/kristijanhusak/vim-dadbod-ui/assets/59935328/ca303b02-0547-497f-95fe-d01b4185ef11)

</details>