### PR TITLE
fix(postgres): Primary Keys table helper

### DIFF
--- a/autoload/db_ui/table_helpers.vim
+++ b/autoload/db_ui/table_helpers.vim
@@ -1,4 +1,4 @@
-let s:basic_constraint_query = "
+let s:basic_foreign_key_query = "
       \SELECT tc.constraint_name, tc.table_name, kcu.column_name, ccu.table_name AS foreign_table_name, ccu.column_name AS foreign_column_name, rc.update_rule, rc.delete_rule\n
       \FROM\n
       \     information_schema.table_constraints AS tc\n
@@ -19,8 +19,8 @@ let s:postgres = {
       \ 'List': 'select * from {optional_schema}"{table}" LIMIT 200',
       \ 'Columns': "select * from information_schema.columns where table_name='{table}' and table_schema='{schema}'",
       \ 'Indexes': "SELECT * FROM pg_indexes where tablename='{table}' and schemaname='{schema}'",
-      \ 'Foreign Keys': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
-      \ 'References': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand ccu.table_name = '{table}'\nand tc.table_schema = '{schema}'",
+      \ 'Foreign Keys': s:basic_foreign_key_query."WHERE constraint_type = 'FOREIGN KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
+      \ 'References': s:basic_foreign_key_query."WHERE constraint_type = 'FOREIGN KEY'\nand ccu.table_name = '{table}'\nand tc.table_schema = '{schema}'",
       \ 'Primary Keys': "SELECT * FROM information_schema.table_constraints WHERE constraint_type = 'PRIMARY KEY' AND table_schema = '{schema}' AND table_name = '{table}'",
       \ }
 

--- a/autoload/db_ui/table_helpers.vim
+++ b/autoload/db_ui/table_helpers.vim
@@ -21,7 +21,7 @@ let s:postgres = {
       \ 'Indexes': "SELECT * FROM pg_indexes where tablename='{table}' and schemaname='{schema}'",
       \ 'Foreign Keys': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
       \ 'References': s:basic_constraint_query."WHERE constraint_type = 'FOREIGN KEY'\nand ccu.table_name = '{table}'\nand tc.table_schema = '{schema}'",
-      \ 'Primary Keys': s:basic_constraint_query."WHERE constraint_type = 'PRIMARY KEY'\nand tc.table_name = '{table}'\nand tc.table_schema = '{schema}'",
+      \ 'Primary Keys': "SELECT * FROM information_schema.table_constraints WHERE constraint_type = 'PRIMARY KEY' AND table_schema = '{schema}' AND table_name = '{table}'",
       \ }
 
 let s:sqlite = {


### PR DESCRIPTION
The current Primary Keys table helper for Postgres doesn't list primary keys as expected because it joins against `information_schema.referential_constraints`, which only has foreign keys.

To reproduce:
1. Spin up the current stable version of PostgreSQL (16.3).
2. Create a table with a primary key:
```sql
CREATE TABLE pk_test (
  id INT,
  name TEXT,
  PRIMARY KEY (id)
);
```
3. Run the existing Primary Keys table helper and see that the primary key is not listed.

<hr>

This PR fixes the Primary Keys table helper by simply querying against `information_schema.table_constraints`. It also renames `basic_constraint_query` to indicate it should only be used for foreign key queries.
