### PR TITLE
fix: stop overriding `list` in query files

### DIFF
--- a/autoload/db_ui/query.vim
+++ b/autoload/db_ui/query.vim
@@ -167,7 +167,7 @@ function! s:query.setup_buffer(db, opts, buffer_name, was_single_win) abort
   endif
 
   if &filetype !=? a:db.filetype || !is_existing_buffer
-    silent! exe 'setlocal filetype='.a:db.filetype.' noswapfile nowrap nospell modifiable'
+    silent! exe 'setlocal noswapfile nowrap nospell modifiable filetype='.a:db.filetype
   endif
   let is_sql = &filetype ==? a:db.filetype
   nnoremap <silent><buffer><Plug>(DBUI_EditBindParameters) :call <sid>method('edit_bind_parameters')<CR>

--- a/autoload/db_ui/query.vim
+++ b/autoload/db_ui/query.vim
@@ -167,7 +167,7 @@ function! s:query.setup_buffer(db, opts, buffer_name, was_single_win) abort
   endif
 
   if &filetype !=? a:db.filetype || !is_existing_buffer
-    silent! exe 'setlocal filetype='.a:db.filetype.' nolist noswapfile nowrap nospell modifiable'
+    silent! exe 'setlocal filetype='.a:db.filetype.' noswapfile nowrap nospell modifiable'
   endif
   let is_sql = &filetype ==? a:db.filetype
   nnoremap <silent><buffer><Plug>(DBUI_EditBindParameters) :call <sid>method('edit_bind_parameters')<CR>


### PR DESCRIPTION
Concerns
--------

* [ ] Should I revert (or rebase-drop) 296374a (refactor: set `filetype` after other options, 2024-08-07)?
    * This is a bit beyond what you suggested but I thought it'd be useful for people who prefer line-wrapping (for example).

Description
-----------

Resolves #267.

~~~diff
commit 296374af294d41a2ea15017adb9c2ee146ee5f6c
Author: ss-raicangu <ssCm181126@outlook.com>
Date:   2024-08-07T23:07:24+12:00

    refactor: set `filetype` after other options
    
    This allows filetype plugins, such as `mysql.vim`, to override any of
    the special query buffer settings if needed.
    
    A similar pattern of setting `filetype` before other settings is present
    for the DBUI drawer. I assume this is more deliberate, and is out of
    scope for kristijanhusak/vim-dadbod-ui#267, so I haven't changed this
    part.
    
    This change was not signed off, so might be reverted.
    
    BREAKING-CHANGE: Options set in filetype plugins are now preferred for
                     query buffers.
    Link: https://github.com/kristijanhusak/vim-dadbod-ui/blob/0f51d8de368c8c6220973e8acd156d17da746f4c/autoload/db_ui/drawer.vim?plain=1#L38

commit 607d1c17bf5245553e7b20a277c951f664acaf92
Author: ss-raicangu <ssCm181126@outlook.com>
Date:   2024-08-07T22:57:22+12:00

    fix: stop overriding `list` in query files
    
    Problem: `list`-mode characters are not being shown in `dadbod-ui` query
             buffers and the filetype plugin setting is always being
             overridden.
    Solution: Remove `nolist` after `setlocal filetype`, so that the `list`
              preference is honoured.
    Signed-off-by: Kristijan Husak <husakkristijan@gmail.com>
~~~