### PR TITLE
fix(bigquery): Increase the number of schemas / tables fetched to 100000

### DIFF
--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -198,9 +198,10 @@ let s:bigquery_schema_tables_query = printf("
       \ FROM `%s`.INFORMATION_SCHEMA.TABLES
       \ ", g:db_adapter_bigquery_region)
 
+let s:db_adapter_bigquery_max_results = 100000
 let s:bigquery = {
       \ 'callable': 'filter',
-      \ 'args': ['--format=csv'],
+      \ 'args': ['--format=csv', '--max_rows=' .. s:db_adapter_bigquery_max_results],
       \ 'schemes_query': s:bigquery_schemas_query,
       \ 'schemes_tables_query': s:bigquery_schema_tables_query,
       \ 'parse_results': {results, min_len -> s:results_parser(results[1:], ',', min_len)},


### PR DESCRIPTION
The number of tables / schemas fetched from the BigQuery adapter is limited to 100 by default, which caused my database to randomly skip some tables / schemas when syncing. 

With this change I Increase this number to a big enough number so that all tables / schemas are included.