### PR TITLE
Suppress "No fold found" with :silent!

### DIFF
--- a/plugin/db_ui.vim
+++ b/plugin/db_ui.vim
@@ -119,7 +119,7 @@ augroup dbui
   autocmd!
   autocmd BufRead,BufNewFile *.dbout set filetype=dbout
   autocmd BufReadPost *.dbout nested call db_ui#save_dbout(expand('<afile>'))
-  autocmd FileType dbout setlocal foldmethod=expr foldexpr=db_ui#dbout#foldexpr(v:lnum) | normal!zo
+  autocmd FileType dbout setlocal foldmethod=expr foldexpr=db_ui#dbout#foldexpr(v:lnum) | silent! normal!zo
   autocmd FileType dbout,dbui autocmd BufEnter,WinEnter <buffer> stopinsert
 augroup END
 


### PR DESCRIPTION
Some adapters output a blank line as the first line of the `dbout` buffer, e.g. `oracle` with `sqlplus`. In this situation, an error is currently thrown on each execution, as the `FileType dbout` auto-command calls `normal!zo` with the cursor on the first line, which is not in a fold.

This PR simply suppresses that error with `:silent!`