### PR TITLE
fix(notifications): use `vim.log.levels`

### DIFF
--- a/autoload/db_ui/notifications.vim
+++ b/autoload/db_ui/notifications.vim
@@ -95,7 +95,14 @@ function! s:notification_nvim_notify(msg, opts) abort
   if get(a:opts, 'delay')
     let opts.timeout = { 'timeout': a:opts.delay }
   endif
-  return luaeval('vim.notify(_A[1], _A[2], _A[3])', [a:msg, type, opts])
+
+  let log_levels = {
+    \ 'info': luaeval("vim.log.levels.INFO"),
+    \ 'error': luaeval("vim.log.levels.ERROR"),
+    \ 'warning': luaeval("vim.log.levels.WARN")
+  \ }
+
+  return luaeval('vim.notify(_A[1], _A[2], _A[3])', [a:msg, log_levels[type], opts])
 endfunction
 
 function! s:notification_nvim(msg, opts) abort


### PR DESCRIPTION
### Fix: Use accepted `vim.log.levels` values for native Neovim notifications

I encountered an issue with [mini.notify](https://github.com/echasnovski/mini.notify):

```
Error detected while processing function <SNR>79_method[2]..60[30]..63[7]..34[16]..function <SNR>79_method[2]..60[30]..63[7]..34[15]..db_ui#notifications#error[1]..<SNR>83_notification[11]. .<SNR>83_notification_nvim_notify: line 7: E5108: Error executing lua (mini.notify) Only valid values of vim.log.levels are supported. stack traceback: [C]: in function 'error' ...ack/myNeovimPackages/start/mini.nvim/lua/mini/notify.lua:839: in function 'error' ...ack/myNeovimPackages/start/mini.nvim/lua/mini/notify.lua:305: in function 'notify' [string "luaeval()"]:1: in main chunk
```

The error was caused by `mini.notify` not using accepted values from [`vim.log.levels`](https://neovim.io/doc/user/lua.html#vim.log.levels) for `vim.notify`. After applying these changes, native Neovim notifications now work as expected.