### PR TITLE
feat(oracle): check dbext_default_ORA_bin as  'sql' or 'sqlcl'

### DIFF
--- a/autoload/db_ui/schemas.vim
+++ b/autoload/db_ui/schemas.vim
@@ -180,7 +180,7 @@ let s:oracle = {
       \   'filetype': 'plsql',
       \ }
 
-if get(g:, 'dbext_default_ORA_bin', '') == 'sql'
+if index(['sql', 'sqlcl'], get(g:, 'dbext_default_ORA_bin', '')) >= 0
   let s:oracle.parse_results = {results, min_len -> s:results_parser(s:strip_quotes(results[3:]), ',', min_len)}
   let s:oracle.parse_virtual_results = {results, min_len -> s:results_parser(s:strip_quotes(results[3:]), ',', min_len)}
 endif


### PR DESCRIPTION
I had some problems where the SQLCL binary was named 'sqlcl' instead of 'sql' which caused some issues with parsing the response, since the default is to expect data in SQLPlus's format.

