### PR TITLE
fix(notification): swap notifications info colours

### DIFF
--- a/autoload/db_ui/notifications.vim
+++ b/autoload/db_ui/notifications.vim
@@ -219,7 +219,7 @@ function! s:setup_colors() abort
     let normal_fg = '#FFFFFF'
   endif
 
-  call s:set_hl('NotificationInfo', normal_bg, normal_fg)
+  call s:set_hl('NotificationInfo', normal_fg, normal_bg)
   call s:set_hl('NotificationError', error_fg, error_bg)
   call s:set_hl('NotificationWarning', warning_fg, warning_bg)
 


### PR DESCRIPTION
## background
recently I fallback my colorscheme into the default colorscheme and decided to not use any syntax highlighting (but this shouldn't be the case) because I think the `hl` tag only respects from colorscheme rather than syntax, but what I found interesting is in the `setup_colors()` function in which we add a default color for the notification.

in my case the bg and fg were overlapped and the notification only shows full black, and after swapping the `hl` for `NotificationInfo` it works with displaying the `guifg` (because in the default colorscheme, i think only `guibg` are declared).

here are some comparison with different "default" colorscheme...

### before the swap
![Screenshot 2024-11-22 at 05 26 46](https://github.com/user-attachments/assets/f2c66dda-e471-482b-bcdd-a1d53fc7d406)
![Screenshot 2024-11-22 at 05 34 16](https://github.com/user-attachments/assets/bdacafb8-42a3-4dfb-ae61-a1db4cc69203)

### after the swap
![Screenshot 2024-11-22 at 05 25 42](https://github.com/user-attachments/assets/ba81942b-0754-4749-8a9b-b2e223062572)
![Screenshot 2024-11-22 at 05 33 38](https://github.com/user-attachments/assets/5c48ee50-89ac-47c7-83f2-591d0d5a8207)

## steps to reproduce
1. change to default colorscheme (black background) or only have a `guibg` hl set
2. run query
