### PR TITLE
allow removing default table helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,15 @@ let g:db_ui_table_helpers = {
 \ }
 ```
 
+Overriding a helper with an empty string will remove it.
+```vimL
+let g:db_ui_table_helpers = {
+\   'postgresql': {
+\     'List': ''
+\   }
+\ }
+```
+
 ### Auto execute query
 If this is set to `1`, opening any of the table helpers will also automatically execute the query.
 

--- a/autoload/db_ui/table_helpers.vim
+++ b/autoload/db_ui/table_helpers.vim
@@ -215,5 +215,15 @@ function! db_ui#table_helpers#get(scheme) abort
     let result = extend(result, get(g:db_ui_table_helpers, s:scheme_map[a:scheme], {}))
   endif
 
+  for [key, value] in items(result)
+    if value == ''
+      call remove(result, key)
+    endif
+  endfor
+
+  if empty(result)
+    let result['List'] = ''
+  endif
+
   return result
 endfunction

--- a/doc/dadbod-ui.txt
+++ b/doc/dadbod-ui.txt
@@ -476,6 +476,16 @@ defaults by passing in the matching helper name. To override `List`, do this:
 	\ 	}
  	\ }
 
+Overriding a default helper with an empty string will remove it:
+
+>
+ 	let g:db_ui_table_helpers = {
+	\ 	'postgresql': {
+	\ 		'List': ''
+	\ 	}
+ 	\ }
+
+
 Note that `{last_query}` will be empty if no queries were ran before opening
 that helper. Also, in the `EXPLAIN` example above, running the explain helper
 and then running it again for another table will print double `EXPLAIN ANALYZE`


### PR DESCRIPTION
This will let users to remove default table helpers. I have something like the following in my neovim config:
```lua
vim.cmd([[
let g:db_ui_table_helpers = {
\   'postgresql': {
\     'Columns': "",
\     'Primary Keys': "",
\     'Indexes': "",
\     'References': "",
\     'Foreign Keys': "",
\     'All Info': "select * from information_schema.columns where table_name='{table}' and table_schema='{schema}';\n
\select * from pg_indexes where tablename='{table}' and schemaname='{schema}';\n
\select conrelid::regclass as table_from, conname, pg_get_constraintdef(oid) from pg_constraint\n
\where conrelid::regclass::text = '{schema}.{table}'\n
\order by contype desc;"
\   }
\ }
]])
```

Which removes the default helpers I don't use.