### PR TITLE
dbout: set foldmethod in ftplugin instead of ft autocommand

### DIFF
--- a/ftplugin/dbout.vim
+++ b/ftplugin/dbout.vim
@@ -4,6 +4,8 @@ nnoremap <silent><buffer> <Plug>(DBUI_YankHeader) :call db_ui#dbout#yank_header(
 nnoremap <silent><buffer> <Plug>(DBUI_ToggleResultLayout) :call db_ui#dbout#toggle_layout()<CR>
 omap <silent><buffer> ic :call db_ui#dbout#get_cell_value()<CR>
 
+setlocal foldmethod=expr foldexpr=db_ui#dbout#foldexpr(v:lnum) | silent! normal!zo
+
 if get(g:, 'db_ui_disable_mappings', 0) || get(g:, 'db_ui_disable_mappings_dbout', 0)
   finish
 endif

--- a/plugin/db_ui.vim
+++ b/plugin/db_ui.vim
@@ -123,7 +123,6 @@ augroup dbui
   autocmd!
   autocmd BufRead,BufNewFile *.dbout set filetype=dbout
   autocmd BufReadPost *.dbout nested call db_ui#save_dbout(expand('<afile>'))
-  autocmd FileType dbout setlocal foldmethod=expr foldexpr=db_ui#dbout#foldexpr(v:lnum) | silent! normal!zo
   autocmd FileType dbout,dbui autocmd BufEnter,WinEnter <buffer> stopinsert
 augroup END
 


### PR DESCRIPTION
an ftplugin setting is overridable by the user through after/ftplugin.

i actually couldn't find a way to override the foldmethod at all without that change (maybe it's posisble, but i couldn't find a way). With this change, it's trivial: i just set the foldmethod in my ftplugin/after...

i'm using dadbod to query json (both in postgresql and jq), and i can have much better folding than what dadbod-ui can offer me out of the box. but i need control for that...

thanks for great plugins!