### PR TITLE
fix(buffers): slugify db name for buffer matching and generation

### DIFF
--- a/autoload/db_ui.vim
+++ b/autoload/db_ui.vim
@@ -237,7 +237,8 @@ function! s:dbui.generate_new_db_entry(db) abort
   if !empty(self.save_path)
     let save_path = printf('%s/%s', self.save_path, a:db.name)
   endif
-  let buffers = filter(copy(self.old_buffers), 'fnamemodify(v:val, ":e") =~? "^".a:db.name."-" || fnamemodify(v:val, ":t") =~? "^".a:db.name."-"')
+  let db_name_slug = db_ui#utils#slug(a:db.name)
+  let buffers = filter(copy(self.old_buffers), 'fnamemodify(v:val, ":e") =~? "^".db_name_slug."-" || fnamemodify(v:val, ":t") =~? "^".db_name_slug."-"')
 
   let db = {
         \ 'url': a:db.url,

--- a/autoload/db_ui/query.vim
+++ b/autoload/db_ui/query.vim
@@ -53,7 +53,7 @@ function! s:query.generate_buffer_name(db, opts) abort
   let buffer_name = db_ui#utils#slug(printf('%s-%s', a:db.name, suffix))
   let buffer_name = printf('%s-%s', buffer_name, time)
   if type(g:Db_ui_buffer_name_generator) ==? type(function('tr'))
-    let buffer_name = printf('%s-%s', a:db.name, call(g:Db_ui_buffer_name_generator, [a:opts]))
+    let buffer_name = printf('%s-%s', db_ui#utils#slug(a:db.name), call(g:Db_ui_buffer_name_generator, [a:opts]))
   endif
 
   if !empty(self.drawer.dbui.tmp_location)


### PR DESCRIPTION
- Slugify database name when matching existing buffers in `generate_new_db_entry()` and when constructing buffer names in the custom `g:Db_ui_buffer_name_generator` path
- Fixes buffer recovery failing for database names containing spaces or special characters (e.g. `"my database"` → slug `"mydatabase"` now matches buffer filenames correctly)
